### PR TITLE
Correzione da toenj.it a enjy.me

### DIFF
--- a/01 Abruzzo
+++ b/01 Abruzzo
@@ -8,7 +8,7 @@ _Info dal Comune di Scerni_
 [M5S ABRUZZO](https://t.me/m5sabruzzo)
 _info dal MoVimento 5 Stelle Abruzzo (Parlamento, Regione, Comuni)_
 
-👥 Gruppo consigliato: [Abruzzo Community](toenj.it/abruzzo)
+👥 Gruppo consigliato: [Abruzzo Community](https://enjy.me/abruzzo)
 
 Per i quotidiani nazionali [clicca qui 🇮🇹](https://t.me/OTInews/99)
 🔗 [@OTIfeed](t.me/OTIfeed/99)

--- a/02 Basilicata
+++ b/02 Basilicata
@@ -1,6 +1,6 @@
 📰 *BASILICATA* 🗞
 
-👥 Gruppo consigliato: [Basilicata Community](toenj.it/basilicata)
+👥 Gruppo consigliato: [Basilicata Community](https://enjy.me/basilicata)
 
 🏛 *Istituzionali* 📜
 [Comune di Filiano](https://t.me/comunedifiliano)

--- a/03 Calabria
+++ b/03 Calabria
@@ -2,7 +2,7 @@
 
 [Calabria Channel Eventi](https://t.me/joinchat/AAAAAEGhpO0RG2QW173cAQ)
 _dedicato alla condivisione di Eventi in Calabria_
-👥 Gruppi consigliati: [Calabria Community](toenj.it/calabria) & [Calabria Group](https://t.me/CalabriaGroup)
+👥 Gruppi consigliati: [Calabria Community](https://enjy.me/calabria) & [Calabria Group](https://t.me/CalabriaGroup)
 
 🏛 *Istituzionali* 📜
 [Arpacalsocial](https://t.me/arpacal)

--- a/04 Campania
+++ b/04 Campania
@@ -8,7 +8,7 @@ _tutte le news di caserta.zon.it, sito web di notizie e media_
 _le notizie, ogni giorno, da L'Occhio di Salerno_
 [Naples Experience](https://t.me/naplesexperience)
 _Napoli intesa come luogo o stato d'animo. Aggiornamenti su città ed eventi_
-👥 Gruppo consigliato: [Campania Community](toenj.it/campania)
+👥 Gruppo consigliato: [Campania Community](https://enjy.me/campania)
 
 🏛 *Istituzionali* 📜
 [PD Napoli](https://t.me/pdnapoli)

--- a/05 Emilia-Romagna
+++ b/05 Emilia-Romagna
@@ -1,6 +1,6 @@
 📰 *EMILIA-ROMAGNA* 🗞
 
-👥 Gruppo consigliato: [Emilia-Romagna Community](toenj.it/emilia-romagna)
+👥 Gruppo consigliato: [Emilia-Romagna Community](https://enjy.me/emilia-romagna)
 
 🏛 *Istituzionali* 📜
 [Comune di Rimini - News](https://t.me/comunedirimininews)

--- a/06 Friuli-Venezia Giulia
+++ b/06 Friuli-Venezia Giulia
@@ -1,6 +1,6 @@
 📰 *FRIULI-VENEZIA GIULIA* 🗞
 
-👥 Gruppo consigliato: [Friuli-Venezia Giulia Community](toenj.it/friuli-venezia-giulia)
+👥 Gruppo consigliato: [Friuli-Venezia Giulia Community](https://enjy.me/friuli-venezia-giulia)
 
 🏛 *Istituzionali* 📜
 [Comune di Trieste](https://t.me/comunetrieste)

--- a/07 Lazio
+++ b/07 Lazio
@@ -1,6 +1,6 @@
 📰 *LAZIO* 🗞
 
-👥 Gruppo consigliato: [Lazio Community](toenj.it/lazio)
+👥 Gruppo consigliato: [Lazio Community](https://enjy.me/lazio)
 
 🏛 *Istituzionali* 📜
 [ComuneManziana](https://t.me/ComuneManziana)

--- a/08 Liguria
+++ b/08 Liguria
@@ -1,6 +1,6 @@
 📰 *LIGURIA* 🗞
 
-👥 Gruppi consigliati: [Liguria Community](toenj.it/liguria) e [MareMonti - Liguria su TG](https://t.me/maremonti_liguria_group)
+👥 Gruppi consigliati: [Liguria Community](https://enjy.me/liguria) e [MareMonti - Liguria su TG](https://t.me/maremonti_liguria_group)
 
 🏛 *Istituzionali* 📜
 [Comune di Giustenice](https://t.me/comunegiustenice)

--- a/09 Lombardia
+++ b/09 Lombardia
@@ -2,7 +2,7 @@
 
 [L'eco di Bergamo](https://t.me/ecodibergamo)
 _canale ufficiale_
-👥 Gruppo consigliato: [Lombardia Community](toenj.it/lombardia)
+👥 Gruppo consigliato: [Lombardia Community](https://enjy.me/lombardia)
 
 🏛 *Istituzionali* 📜
 [Comune di Busto Garolfo](https://t.me/comuneBG)

--- a/10 Marche
+++ b/10 Marche
@@ -7,7 +7,7 @@ _da Macerata e provincia_
 [Vivere Marche](https://t.me/viveremarche)
 _notizie in tempo reale, da tutta la regione_
 In particolare: [Urbino](https://t.me/vivereurbino), [Pesaro](https://t.me/viverepesaro), [Fano](https://t.me/viverefano), [Senigallia](https://t.me/viverefano), [Ancona](https://t.me/vivereancona), [Jesi (Vallesina)](https://t.me/viverejesi), [Camerino, San Severino e Matelica](https://t.me/viverecamerino), [Fermo](https://t.me/viverefermo), [San Benedetto del Tronto](https://t.me/viveresanbenedetto)
-👥 Gruppo consigliato: [Marche Community](toenj.it/marche)
+👥 Gruppo consigliato: [Marche Community](https://enjy.me/marche)
 
 🏛 *Istituzionali* 📜
 [ComunediSirolo](https://t.me/comunedisirolo)

--- a/11 Molise
+++ b/11 Molise
@@ -1,6 +1,6 @@
 📰 *MOLISE* 🗞
 
-👥 Gruppo consigliato: [Molise Community](toenj.it/molise)
+👥 Gruppo consigliato: [Molise Community](https://enjy.me/molise)
 
 Per i quotidiani nazionali [clicca qui 🇮🇹](https://t.me/OTInews/99)
 🔗 [@OTIfeed](t.me/OTIfeed/99)

--- a/12 Piemonte
+++ b/12 Piemonte
@@ -2,7 +2,7 @@
 
 [Piemonte news](https://t.me/piemontenews)
 _le notizie di Quotidiano Piemontese_
-👥 Gruppo consigliato: [Piemonte Community](toenj.it/piemonte)
+👥 Gruppo consigliato: [Piemonte Community](https://enjy.me/piemonte)
 
 🏛 *Istituzionali* 📜
 [BorgoBot](t.me/BorgoBot)

--- a/13 Puglia
+++ b/13 Puglia
@@ -1,6 +1,6 @@
 📰 *PUGLIA* 🗞
 
-👥 Gruppo consigliato: [Puglia Community](toenj.it/puglia)
+👥 Gruppo consigliato: [Puglia Community](https://enjy.me/puglia)
 
 🏛 *Istituzionali* 📜
 [Comune di Melendugno](https://t.me/comunedimelendugno)

--- a/14 Sardegna
+++ b/14 Sardegna
@@ -1,6 +1,6 @@
 📰 *SARDEGNA* 🗞
 
-👥 Gruppo consigliato: [Sardegna Community](toenj.it/sardegna)
+👥 Gruppo consigliato: [Sardegna Community](https://enjy.me/sardegna)
 
 Per i quotidiani nazionali [clicca qui 🇮🇹](https://t.me/OTInews/99)
 🔗 [@OTIfeed](t.me/OTIfeed/99)

--- a/15 Sicilia
+++ b/15 Sicilia
@@ -1,6 +1,6 @@
 📰 *SICILIA* 🗞
 
-👥 Gruppo consigliato: [Sicilia Community](toenj.it/sicilia)
+👥 Gruppo consigliato: [Sicilia Community](https://enjy.me/sicilia)
 
 🏛 *Istituzionali* 📜
 [Comune di Mascalucia](https://t.me/comunemascalucia)

--- a/16 Toscana
+++ b/16 Toscana
@@ -1,6 +1,6 @@
 📰 *TOSCANA* 🗞
 
-👥 Gruppo consigliato: [Toscana Community](toenj.it/toscana)
+👥 Gruppo consigliato: [Toscana Community](https://enjy.me/toscana)
 
 🏛 *Istituzionali* 📜
 [Intoscana.it](https://t.me/intoscana)

--- a/17 Trentino-Alto Adige
+++ b/17 Trentino-Alto Adige
@@ -2,7 +2,7 @@
 
 [TrentinoNews](https://t.me/trentinonews)
 _notizie da www.ladige.it_
-👥 Gruppo consigliato: [Trentino-Alto Adige Community](toenj.it/trentino-alto-adige)
+👥 Gruppo consigliato: [Trentino-Alto Adige Community](https://enjy.me/trentino-alto-adige)
 
 Per i quotidiani nazionali [clicca qui 🇮🇹](https://t.me/OTInews/99)
 🔗 [@OTIfeed](t.me/OTIfeed/99)

--- a/18 Umbria
+++ b/18 Umbria
@@ -2,7 +2,7 @@
 
 [Umbrianotizie](https://t.me/umbrianotizie)
 _notizie ed eventi_
-👥 Gruppo consigliato: [Umbria Community](toenj.it/umbria)
+👥 Gruppo consigliato: [Umbria Community](https://enjy.me/umbria)
 
 Per i quotidiani nazionali [clicca qui 🇮🇹](https://t.me/OTInews/99)
 🔗 [@OTIfeed](t.me/OTIfeed/99)

--- a/19 Valle d'Aosta
+++ b/19 Valle d'Aosta
@@ -1,6 +1,6 @@
 📰 *VALLE D'AOSTA* 🗞
 
-👥 Gruppo consigliato: [Valle d'Aosta Community](toenj.it/valle-daosta)
+👥 Gruppo consigliato: [Valle d'Aosta Community](https://enjy.me/valle-daosta)
 
 Per i quotidiani nazionali [clicca qui 🇮🇹](https://t.me/OTInews/99)
 🔗 [@OTIfeed](t.me/OTIfeed/99)

--- a/20 Veneto
+++ b/20 Veneto
@@ -2,7 +2,7 @@
 
 [L'Arena di Verona](https://t.me/larenadiverona)
 _le notizie principali dal sito www.larena.it_
-👥 Gruppi consigliati: [Veneto Community](toenj.it/veneto) e [Veneto](https://t.me/veneto)
+👥 Gruppi consigliati: [Veneto Community](https://enjy.me/veneto) e [Veneto](https://t.me/veneto)
 
 🏛 *Istituzionali* 📜
 [Academia de ła Bona Creansa](https://t.me/AcademiaLenguaVeneta)


### PR DESCRIPTION
Corretti i link con il nuovo servizio di URL shortner